### PR TITLE
Adding option for single letter log levels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ erl_crash.dump
 *.ez
 
 .elixir_ls
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Config | Default | Description
 `full_level_names` | false | display `DEBUG` and `ERROR` instead of their four-letter equivalents (DEBG, EROR)
 `level_names` | :full | display `DEBUG` and `ERROR` instead of their four-letter equivalents (DEBG, EROR)
 `level_names` | :single | display `D` and `E` instead of their four-letter equivalents (DEBG, EROR)
-`level_names` | :default | displays the default four-letter log levels. If this is not specified nor full_level_names, this is the default behaviour. 
+`level_names` | :default | displays the default four-letter log levels. If this is not specified nor `full_level_names`, this is the default behaviour. 
 `show_elixir_prefix` | false | remove the `Elixir.` module prefix when displaying the module name
 `show_date` | false | includes the date in the log timestamp
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Config | Default | Description
 `padding` | 44 | the minimum character width of the main log message
 `pad_empty_messages` | false | the Logrex formatter will not apply padding to empty messages, unless set to 'true'
 `full_level_names` | false | display `DEBUG` and `ERROR` instead of their four-letter equivalents (DEBG, EROR)
+`level_names` | :full | display `DEBUG` and `ERROR` instead of their four-letter equivalents (DEBG, EROR)
+`level_names` | :single | display `D` and `E` instead of their four-letter equivalents (DEBG, EROR)
+`level_names` | :default | displays the default four-letter log levels. If this is not specified nor full_level_names, this is the default behaviour. 
 `show_elixir_prefix` | false | remove the `Elixir.` module prefix when displaying the module name
 `show_date` | false | includes the date in the log timestamp
 

--- a/lib/logrex_formatter.ex
+++ b/lib/logrex_formatter.ex
@@ -31,10 +31,10 @@ defmodule Logrex.Formatter do
   }
 
   @level_names %{
-    debug: %{short: "DEBG", long: "DEBUG"},
-    info: %{short: "INFO", long: "INFO"},
-    warn: %{short: "WARN", long: "WARN"},
-    error: %{short: "EROR", long: "ERROR"}
+    debug: %{short: "DEBG", long: "DEBUG", single: "D"},
+    info: %{short: "INFO", long: "INFO", single: "I"},
+    warn: %{short: "WARN", long: "WARN", single: "W"},
+    error: %{short: "EROR", long: "ERROR", single: "E"}
   }
 
   @typep erl_datetime :: {{integer, integer, integer}, {integer, integer, integer, integer}}
@@ -144,8 +144,11 @@ defmodule Logrex.Formatter do
       to_string(val)
     end
   end
-
+  
   defp level_name(level, %{full_level_names: true}), do: @level_names[level].long
+  defp level_name(level, %{level_name: :full}), do: @level_names[level].long
+  defp level_name(level, %{level_name: :single}), do: @level_names[level].single
+  defp level_name(level, %{level_name: :default}), do: @level_names[level].short
   defp level_name(level, _config), do: @level_names[level].short
 
   defp get_colors do

--- a/lib/logrex_formatter.ex
+++ b/lib/logrex_formatter.ex
@@ -145,11 +145,9 @@ defmodule Logrex.Formatter do
     end
   end
   
-  defp level_name(level, %{full_level_names: true}), do: @level_names[level].long
-  defp level_name(level, %{full_level_names: false}), do: @level_names[level].short
   defp level_name(level, %{level_names: :full}), do: @level_names[level].long
   defp level_name(level, %{level_names: :single}), do: @level_names[level].single
-  defp level_name(level, %{level_names: :default}), do: @level_names[level].short
+  defp level_name(level, %{level_names: :short}), do: @level_names[level].short
   defp level_name(level, _config), do: @level_names[level].short
 
   defp get_colors do

--- a/lib/logrex_formatter.ex
+++ b/lib/logrex_formatter.ex
@@ -146,9 +146,10 @@ defmodule Logrex.Formatter do
   end
   
   defp level_name(level, %{full_level_names: true}), do: @level_names[level].long
-  defp level_name(level, %{level_name: :full}), do: @level_names[level].long
-  defp level_name(level, %{level_name: :single}), do: @level_names[level].single
-  defp level_name(level, %{level_name: :default}), do: @level_names[level].short
+  defp level_name(level, %{full_level_names: false}), do: @level_names[level].short
+  defp level_name(level, %{level_names: :full}), do: @level_names[level].long
+  defp level_name(level, %{level_names: :single}), do: @level_names[level].single
+  defp level_name(level, %{level_names: :default}), do: @level_names[level].short
   defp level_name(level, _config), do: @level_names[level].short
 
   defp get_colors do

--- a/test/logrex_formatter_test.exs
+++ b/test/logrex_formatter_test.exs
@@ -162,43 +162,7 @@ defmodule LogrexFormatterTest do
     end
   end
 
-  describe "full_level_names config" do
-    test "displays full level names when true" do
-      Application.put_env(:logrex, :full_level_names, true)
-
-      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
-      expect = "ERROR 10:20:30"
-      assert result |> Enum.join("") |> rem_color =~ expect
-    end
-    test "displays full level names when true even if level_names is set" do
-      Application.put_env(:logrex, :level_names, :single)
-      Application.put_env(:logrex, :full_level_names, true)
-
-      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
-      expect = "ERROR 10:20:30"
-      assert result |> Enum.join("") |> rem_color =~ expect
-    end
-
-    test "displays short level names when not true" do
-      Application.put_env(:logrex, :full_level_names, false)
-
-      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
-      expect = "EROR 10:20:30"
-      assert result |> Enum.join("") |> rem_color =~ expect
-    end
-
-    test "displays short level names when not true, even if level_names is set" do
-      Application.put_env(:logrex, :level_names, :full)
-      Application.put_env(:logrex, :full_level_names, false)
-
-      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
-      expect = "EROR 10:20:30"
-      assert result |> Enum.join("") |> rem_color =~ expect
-
-    end
-  end
-
-  describe "level_name config" do
+  describe "level_names config" do
     test "displays full level names when :full" do
       Application.put_env(:logrex, :level_names, :full)
 
@@ -215,8 +179,8 @@ defmodule LogrexFormatterTest do
       assert result |> Enum.join("") |> rem_color =~ expect
     end
 
-    test "displays short level names when :default" do
-      Application.put_env(:logrex, :level_names, :default)
+    test "displays short level names when :short" do
+      Application.put_env(:logrex, :level_names, :short)
 
       result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
       expect = "EROR 10:20:30"
@@ -297,7 +261,7 @@ defmodule LogrexFormatterTest do
   describe "multiple config options" do
     test "don't intefere with each other" do
       Application.put_env(:logrex, :metadata_format, "pid:$pid")
-      Application.put_env(:logrex, :full_level_names, true)
+      Application.put_env(:logrex, :level_names, :full)
       Application.put_env(:logrex, :padding, 25)
 
       result =

--- a/test/logrex_formatter_test.exs
+++ b/test/logrex_formatter_test.exs
@@ -179,6 +179,39 @@ defmodule LogrexFormatterTest do
     end
   end
 
+  describe "level_name config" do
+    test "displays full level names when :full" do
+      Application.put_env(:logrex, :level_names, :full)
+
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "ERROR 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+    end
+
+    test "displays single letter level names when :single" do
+      Application.put_env(:logrex, :level_names, :single)
+
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "E 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+    end
+
+    test "displays short level names when :default" do
+      Application.put_env(:logrex, :level_names, :default)
+
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "EROR 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+    end
+
+    test "displays short level names when not set" do
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "EROR 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+    end
+
+  end 
+
   describe "colors config" do
     test "includes colors when Logger colors are enabled" do
       Application.put_env(:logger, :colors, enabled: true)

--- a/test/logrex_formatter_test.exs
+++ b/test/logrex_formatter_test.exs
@@ -11,6 +11,7 @@ defmodule LogrexFormatterTest do
       :padding,
       :pad_empty_messages,
       :full_level_names,
+      :level_names,
       :show_elixir_prefix,
       :show_date
     ]
@@ -169,6 +170,14 @@ defmodule LogrexFormatterTest do
       expect = "ERROR 10:20:30"
       assert result |> Enum.join("") |> rem_color =~ expect
     end
+    test "displays full level names when true even if level_names is set" do
+      Application.put_env(:logrex, :level_names, :single)
+      Application.put_env(:logrex, :full_level_names, true)
+
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "ERROR 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+    end
 
     test "displays short level names when not true" do
       Application.put_env(:logrex, :full_level_names, false)
@@ -176,6 +185,16 @@ defmodule LogrexFormatterTest do
       result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
       expect = "EROR 10:20:30"
       assert result |> Enum.join("") |> rem_color =~ expect
+    end
+
+    test "displays short level names when not true, even if level_names is set" do
+      Application.put_env(:logrex, :level_names, :full)
+      Application.put_env(:logrex, :full_level_names, false)
+
+      result = Formatter.format(:error, "", {{1970, 1, 1}, {10, 20, 30, 500}}, a: 1)
+      expect = "EROR 10:20:30"
+      assert result |> Enum.join("") |> rem_color =~ expect
+
     end
   end
 


### PR DESCRIPTION
Change is in addition to the `full_level_names` option to provide backwards compatibility.
`full_level_names` takes precedence over the new `level_names`.

See README for updates regarding the new usage. 
